### PR TITLE
Disable enableMixedTypeHint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.11.x
+
+### v0.11.0
+
+**Breaking changes**
+
+In the following rules the `enableMixedTypeHint` is disabled.
+See explanation and details here: https://github.com/arxeiss/php-coding-standards/pull/6
+
+- SlevomatCodingStandard.TypeHints.ParameterTypeHint
+- SlevomatCodingStandard.TypeHints.PropertyTypeHint
+- SlevomatCodingStandard.TypeHints.ReturnTypeHint
+
 ## v0.10.x
 
 ### v0.10.0

--- a/Rules/phpcs-strict.xml
+++ b/Rules/phpcs-strict.xml
@@ -76,16 +76,28 @@
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/> <!-- Disable long type hints -->
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/> <!-- Parameter must be nullable if has null default value -->
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/> <!-- In doc block |null must be last -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/> <!-- Check correct type hints -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"> <!-- Check correct type hints -->
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation">
         <severity>0</severity>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/> <!-- Correct spacing for parameter type hints -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/> <!-- Check type hint for class property -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"> <!-- Check type hint for class property -->
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation">
         <severity>0</severity>
     </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/> <!-- Correct return type hint -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"> <!-- Correct return type hint -->
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
I believe, that using `mixed` typehint is useless. As that matches everything, you can easily omit it.

Plus frameworks like Laravel sometimes may return different types based on inputs. So return typehint in phpdoc might look like `array<string, string>|mixed`. And linter will add `mixed` typehint and remove phpdoc.

If you like behavior before v0.11 you can easily enable it back. Add those lines into your phpcs.xml file

```xml
<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"> <!-- Check correct type hints -->
    <properties>
        <property name="enableMixedTypeHint" value="true"/>
    </properties>
</rule>
<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"> <!-- Check type hint for class property -->
    <properties>
        <property name="enableMixedTypeHint" value="true"/>
    </properties>
</rule>
<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"> <!-- Correct return type hint -->
    <properties>
        <property name="enableMixedTypeHint" value="true"/>
    </properties>
</rule>
```